### PR TITLE
Fix “Highlight color makes suggestions unreadable”

### DIFF
--- a/xcode-default-dark-theme.json
+++ b/xcode-default-dark-theme.json
@@ -48,6 +48,7 @@
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "tab.activeForeground": "#FFFFFF",
     "panelTitle.inactiveForeground": "#FFFFFF",
+    "list.highlightForeground": "#FFFFFF",
     // blue: accents, highlights, focus
     "editor.lineHighlightBackground": "#2F3239",
     "editor.selectionBackground": "#3D4752",

--- a/xcode-default-light-theme.json
+++ b/xcode-default-light-theme.json
@@ -43,6 +43,7 @@
     "sideBarSectionHeader.foreground": "#282828",
     "panelTitle.inactiveForeground": "#242424",
     "tab.inactiveForeground": "#242424",
+    "list.highlightForeground": "#242424",
     // blue: accents, highlights, focus
     "editor.lineHighlightBackground": "#EEF5FE",
     "focusBorder": "#82ADF3",


### PR DESCRIPTION
Fixes #1 

<img width="578" alt="screen shot 2018-10-30 at 6 08 18 pm" src="https://user-images.githubusercontent.com/3104489/47759893-1402ab80-dc6f-11e8-9af4-3e02590099b4.png">
<img width="472" alt="screen shot 2018-10-30 at 6 08 30 pm" src="https://user-images.githubusercontent.com/3104489/47759898-1a912300-dc6f-11e8-96cc-6db1d2743b78.png">
